### PR TITLE
Update to TypeScript 3.5.1 and fix issues with XPathNSResolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpath-ts",
-  "version": "1.3.9",
+  "version": "1.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1302,9 +1302,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "uri-js": {
@@ -1416,6 +1416,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
       "integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==",
+      "dev": true
+    },
+    "xmldom-ts": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xmldom-ts/-/xmldom-ts-0.2.1.tgz",
+      "integrity": "sha512-iUlqD9iNMRz67jtBI91B4SHStc12XVgLP1LnuRnG2Jmi1oXDe/+1vrfAW3F9KF+33sWM9QRimLb0B2+DmQSocg==",
       "dev": true
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "tslint": "^5.11.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-no-circular-imports": "^0.4.0",
-    "typescript": "^3.4.0",
+    "typescript": "^3.5.1",
     "xmldom-ts": "^0.2.1"
   },
   "main": "./dist/lib/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -51,7 +51,7 @@ export function selectWithResolver(
 export function evaluate(
   expression: string,
   contextNode?: Node,
-  resolver?: XPathNSResolver | ((prefix: string) => string | null) | null,
+  resolver?: XPathNSResolver | null,
   type: number = 0,
   result?: XPathResult | null
 ) {

--- a/src/xpath-evaluator.ts
+++ b/src/xpath-evaluator.ts
@@ -36,7 +36,7 @@ export class XPathEvaluatorImpl implements XPathEvaluator {
   evaluate(
     expression: string,
     contextNode: Node,
-    resolver: XPathNSResolver | ((prefix: string) => string | null) | null,
+    resolver: XPathNSResolver | null,
     type: number,
     result: XPathResult | null
   ) {
@@ -58,7 +58,7 @@ export class XPathEvaluatorImpl implements XPathEvaluator {
   }
 }
 
-function convertNSResolver(resolver: XPathNSResolver | ((prefix: string) => string | null) | null | undefined) {
+function convertNSResolver(resolver: XPathNSResolver | null | undefined) {
   if (resolver == null) {
     return {
       lookupNamespaceURI(_prefix: string): null {
@@ -66,7 +66,7 @@ function convertNSResolver(resolver: XPathNSResolver | ((prefix: string) => stri
       }
     };
   } else if (!isNSResolver(resolver)) {
-    const pr = resolver;
+    const pr: ((prefix: string | null) => string | null) = resolver;
     return {
       lookupNamespaceURI(prefix: string): string | null {
         return pr(prefix);

--- a/src/xpath-ns-resolver-wrapper.ts
+++ b/src/xpath-ns-resolver-wrapper.ts
@@ -1,8 +1,14 @@
+import { isNSResolver } from './utils/types';
+
 export class XPathNSResolverWrapper {
-  xpathNSResolver: XPathNSResolver | null;
+  xpathNSResolver: { lookupNamespaceURI(prefix: string | null): string | null; } | null;
 
   constructor(r: XPathNSResolver | null) {
-    this.xpathNSResolver = r;
+    if (!isNSResolver(r)) {
+      this.xpathNSResolver = null;
+    } else {
+      this.xpathNSResolver = r as { lookupNamespaceURI(prefix: string | null): string | null; };
+    }
   }
 
   getNamespace(prefix: string, _n: Node) {


### PR DESCRIPTION
The PR microsoft/TSJS-lib-generator#578 (and its respective issue microsoft/TypeScript#26437) changed the signature of `XPathNSResolver` by also allowing the `(prefix: string) => string | null)` type in TypeScript 3.5.1 or earlier.

This change broke the build due to some dependencies on `XPathNSResolver`.

My PR updates TypeScript to 3.5.1 and fixes these issues.